### PR TITLE
日本語 / 英語の切り替え機能を追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,8 +28,12 @@
 
 <body>
   <div id="app">
-    <button id="theme-toggle" class="theme-toggle" aria-label="テーマを切り替え">
+    <button id="theme-toggle" class="theme-toggle" aria-label="テーマを切り替え" data-i18n-aria="aria.themeToggle">
       <span class="theme-icon">🌙</span>
+    </button>
+    <button id="lang-toggle" class="lang-toggle" aria-label="日本語 / English" data-i18n-aria="aria.langToggle" title="日本語 / English">
+      <span class="lang-icon">🌐</span>
+      <span class="lang-label" data-i18n="lang.label">日本語</span>
     </button>
     <header class="hero">
       <div class="hero-bg-pattern"></div>
@@ -39,9 +43,9 @@
             <source srcset="/gallery/webp/icon.webp" type="image/webp">
             <img src="/gallery/png/icon.png" alt="icon" class="hero-icon">
           </picture>
-          <h1 class="bounce">雨苺なつき</h1>
+          <h1 class="bounce" data-i18n="hero.name">雨苺なつき</h1>
         </div>
-        <p class="subtitle">✨ Student / Developer / Writer / Photographer ✨</p>
+        <p class="subtitle" data-i18n="hero.subtitle">✨ Student / Developer / Writer / Photographer ✨</p>
       </div>
       <div class="scroll-bubble">
         ⬇
@@ -52,9 +56,9 @@
       <!-- Profile Section -->
       <section id="profile" class="card-panel reveal-fade">
         <div class="deco-tape"></div>
-        <h2>About Me</h2>
+        <h2 data-i18n="profile.sectionTitle">About Me</h2>
         <div class="profile-content">
-          <p>
+          <p data-i18n-html="profile.intro">
             こんにちは！<strong>雨苺なつき</strong>です。<br>
             プログラミングとVRChatが大好きな学生です✨<br>
             ぶいなびで記事を書いたり、便利なツールを作ったりしています！<br>
@@ -62,56 +66,55 @@
             私の活動方針は「<strong>楽しく個人開発する</strong>」「<strong>困ったことを技術で解決する</strong>」ことです。
           </p>
           <div class="role-badges">
-            <span class="badge blue">ぶいなび Operator</span>
-            <span class="badge purple">MofuMagic Owner</span>
-            <span class="badge yellow">VRChat Photographer</span>
+            <span class="badge blue" data-i18n="profile.badgeVrnabi">ぶいなび Operator</span>
+            <span class="badge purple" data-i18n="profile.badgeMofu">MofuMagic Owner</span>
+            <span class="badge yellow" data-i18n="profile.badgePhoto">VRChat Photographer</span>
           </div>
         </div>
       </section>
 
       <!-- Projects Section -->
       <section id="projects" class="pop-in">
-        <h2>Projects</h2>
+        <h2 data-i18n="projects.sectionTitle">Projects</h2>
         <div class="projects-grid">
-          <!-- Rendered dynamically or via data-attributes, but keeping static structure for JS to hook into -->
           <div class="project-card" data-id="vrnavi">
-            <h3>ぶいなび</h3>
-            <p>VRChatの情報をまとめたサイト</p>
+            <h3 data-i18n="project.vrnavi.title">ぶいなび</h3>
+            <p data-i18n="project.vrnavi.desc">VRChatの情報をまとめたサイト</p>
             <div class="tags"><span class="tag">Site</span><span class="tag">WordPress</span></div>
           </div>
           <div class="project-card highlight" data-id="facemixer">
-            <h3>FaceMixer</h3>
-            <p>VRChatのアバター表情改変を簡単に！</p>
+            <h3 data-i18n="project.facemixer.title">FaceMixer</h3>
+            <p data-i18n="project.facemixer.desc">VRChatのアバター表情改変を簡単に！</p>
             <div class="tags"><span class="tag">C#</span><span class="tag">Unity</span><span class="tag">Tool</span></div>
           </div>
           <div class="project-card blue-dark" data-id="cliprack">
-            <h3>ClipRack</h3>
-            <p>macOSで使えるクリップボード管理アプリ</p>
+            <h3 data-i18n="project.cliprack.title">ClipRack</h3>
+            <p data-i18n="project.cliprack.desc">macOSで使えるクリップボード管理アプリ</p>
             <div class="tags"><span class="tag">Swift</span><span class="tag">macOS</span><span class="tag">App</span></div>
           </div>
           <div class="project-card gray" data-id="booth-import">
-            <h3>BOOTH Import Assistant</h3>
-            <p>BOOTHからのインポートを楽にするやつ</p>
+            <h3 data-i18n="project.booth-import.title">BOOTH Import Assistant</h3>
+            <p data-i18n="project.booth-import.desc">BOOTHからのインポートを楽にするやつ</p>
             <div class="tags"><span class="tag">C#</span><span class="tag">JavaScript</span><span class="tag">Efficiency</span></div>
           </div>
           <div class="project-card gray" data-id="booth-library">
-            <h3>BOOTH Library Search</h3>
-            <p>BOOTHライブラリをさくさく検索できるやつ</p>
+            <h3 data-i18n="project.booth-library.title">BOOTH Library Search</h3>
+            <p data-i18n="project.booth-library.desc">BOOTHライブラリをさくさく検索できるやつ</p>
             <div class="tags"><span class="tag">JavaScript</span><span class="tag">Extension</span></div>
           </div>
           <div class="project-card gray" data-id="360-viewer">
-            <h3>360-viewer</h3>
-            <p>Webブラウザで360度画像が見れるビューワー</p>
+            <h3 data-i18n="project.360-viewer.title">360-viewer</h3>
+            <p data-i18n="project.360-viewer.desc">Webブラウザで360度画像が見れるビューワー</p>
             <div class="tags"><span class="tag">JavaScript</span><span class="tag">PHP</span><span class="tag">Web</span></div>
           </div>
           <div class="project-card gray" data-id="timecard">
-            <h3>TimeCard Web</h3>
-            <p>学校課題で作成した勤怠管理サイト</p>
+            <h3 data-i18n="project.timecard.title">TimeCard Web</h3>
+            <p data-i18n="project.timecard.desc">学校課題で作成した勤怠管理サイト</p>
             <div class="tags"><span class="tag">Java</span><span class="tag">Web</span></div>
           </div>
           <div class="project-card gray" data-id="toc-ad">
-            <h3>TOC-AD</h3>
-            <p>WordPressの目次下に広告の画像を自動で追加するプラグイン</p>
+            <h3 data-i18n="project.toc-ad.title">TOC-AD</h3>
+            <p data-i18n="project.toc-ad.desc">WordPressの目次下に広告の画像を自動で追加するプラグイン</p>
             <div class="tags"><span class="tag">PHP</span><span class="tag">WordPress</span></div>
           </div>
         </div>
@@ -119,8 +122,8 @@
 
       <!-- VRChat Gallery Section -->
       <section id="gallery" class="pop-in">
-        <h2>Gallery</h2>
-        <p class="gallery-desc">VRChatでの思い出たち！</p>
+        <h2 data-i18n="gallery.sectionTitle">Gallery</h2>
+        <p class="gallery-desc" data-i18n="gallery.desc">VRChatでの思い出たち！</p>
         <div class="gallery-polaroids">
 
           <div class="polaroid rotate-left">
@@ -130,7 +133,7 @@
                 <img src="/gallery/png/VRChat_2025-07-07_00-27-50.155_2160x3840.png" loading="lazy" alt="VRChat Memory">
               </picture>
             </div>
-            <span class="caption">Summer ☀️</span>
+            <span class="caption" data-i18n="gallery.caption1">Summer ☀️</span>
           </div>
 
           <div class="polaroid rotate-right">
@@ -140,7 +143,7 @@
                 <img src="/gallery/png/VRChat_2025-01-16_02-06-35.432_3840x2160.png" loading="lazy" alt="VRChat Memory">
               </picture>
             </div>
-            <span class="caption">JPT Party 🎉</span>
+            <span class="caption" data-i18n="gallery.caption2">JPT Party 🎉</span>
           </div>
 
           <div class="polaroid rotate-left">
@@ -150,7 +153,7 @@
                 <img src="/gallery/png/VRChat_2025-07-13_05-48-10.021_3840x2160.png" loading="lazy" alt="VRChat Memory">
               </picture>
             </div>
-            <span class="caption">Beautiful View ✨</span>
+            <span class="caption" data-i18n="gallery.caption3">Beautiful View ✨</span>
           </div>
 
           <div class="polaroid rotate-right">
@@ -160,7 +163,7 @@
                 <img src="/gallery/png/VRChat_2025-08-19_03-37-48.990_2160x3840.png" loading="lazy" alt="VRChat Memory">
               </picture>
             </div>
-            <span class="caption">Street Snap 📸</span>
+            <span class="caption" data-i18n="gallery.caption4">Street Snap 📸</span>
           </div>
 
           <div class="polaroid rotate-left">
@@ -170,7 +173,7 @@
                 <img src="/gallery/png/VRChat_2025-10-03_00-39-24.629_3840x2160.png" loading="lazy" alt="VRChat Memory">
               </picture>
             </div>
-            <span class="caption">Memories...</span>
+            <span class="caption" data-i18n="gallery.caption5">Memories...</span>
           </div>
 
           <div class="polaroid rotate-right">
@@ -180,7 +183,7 @@
                 <img src="/gallery/png/VRChat_2025-10-20_03-24-11.849_3840x2160.png" loading="lazy" alt="VRChat Memory">
               </picture>
             </div>
-            <span class="caption">Cute!</span>
+            <span class="caption" data-i18n="gallery.caption6">Cute!</span>
           </div>
 
         </div>
@@ -189,23 +192,23 @@
       <!-- Links Section -->
       <section id="links" class="links-row pop-in">
         <a href="https://twitter.com/mu_natuki" target="_blank" rel="noopener noreferrer" class="link-btn twitter">
-          <span class="icon">X</span> X(Twitter)
+          <span class="icon">X</span> <span data-i18n="links.twitter">X(Twitter)</span>
         </a>
         <a href="https://www.twitch.tv/" target="_blank" rel="noopener noreferrer" class="link-btn twitch">
-          <span class="icon">📺</span> Twitch
+          <span class="icon">📺</span> <span data-i18n="links.twitch">Twitch</span>
         </a>
         <a href="https://mofumagic.booth.pm/" target="_blank" rel="noopener noreferrer" class="link-btn booth">
-          <span class="icon">🛍️</span> BOOTH
+          <span class="icon">🛍️</span> <span data-i18n="links.booth">BOOTH</span>
         </a>
         <a href="https://github.com/natuki53" target="_blank" rel="noopener noreferrer" class="link-btn github">
-          <span class="icon">💻</span> GitHub
+          <span class="icon">💻</span> <span data-i18n="links.github">GitHub</span>
         </a>
       </section>
 
     </main>
 
     <footer>
-      <p>Made with by 雨苺なつき</p>
+      <p data-i18n="footer.text">Made with by 雨苺なつき</p>
     </footer>
 
     <!-- Project Modal -->

--- a/src/english.js
+++ b/src/english.js
@@ -1,0 +1,91 @@
+/**
+ * English translations for data-i18n keys.
+ * index.html uses data-i18n="key" and this object provides the English text.
+ */
+export const en = {
+  // Aria labels
+  'aria.themeToggle': 'Toggle theme',
+  'aria.langToggle': '日本語 / English',
+
+  // Language button label (shows current language name)
+  'lang.label': 'English',
+
+  // Hero
+  'hero.name': 'Amai Natuki',
+  'hero.subtitle': '✨ Student / Developer / Writer / Photographer ✨',
+
+  // Profile
+  'profile.sectionTitle': 'About Me',
+  'profile.intro':
+    'Hi! I\'m <strong>Amai Natuki</strong>.<br>\n' +
+    'I\'m a student who loves programming and VRChat ✨<br>\n' +
+    'I write articles on vrnabi and make handy tools!<br>\n' +
+    '<br>\n' +
+    'My motto is "<strong>Enjoy personal development</strong>" and "<strong>Solve problems with technology</strong>".',
+  'profile.badgeVrnabi': 'vrnabi Operator',
+  'profile.badgeMofu': 'MofuMagic Owner',
+  'profile.badgePhoto': 'VRChat Photographer',
+
+  // Projects section
+  'projects.sectionTitle': 'Projects',
+
+  // Project cards & modal descriptions
+  'project.vrnavi.title': 'vrnabi',
+  'project.vrnavi.desc': 'A site that gathers VRChat information',
+  'project.vrnavi.description':
+    'A site that gathers VRChat information. We share event info, world introductions, and more to help you enjoy VRChat.<br><br>You can try the embedded page below.',
+
+  'project.facemixer.title': 'FaceMixer',
+  'project.facemixer.desc': 'Easy VRChat avatar expression editing!',
+  'project.facemixer.description':
+    'Make VRChat avatar expression editing easy! An intuitive tool to create and edit expressions in Unity.',
+
+  'project.cliprack.title': 'ClipRack',
+  'project.cliprack.desc': 'Clipboard manager app for macOS',
+  'project.cliprack.description':
+    'An app that adds clipboard history so copy-paste is more convenient.',
+
+  'project.booth-import.title': 'BOOTH Import Assistant',
+  'project.booth-import.desc': 'Makes importing from BOOTH easier',
+  'project.booth-import.description':
+    'A tool that makes importing from BOOTH easier. It streamlines importing purchased avatars and outfits. You need to install a browser extension to use it.',
+
+  'project.booth-library.title': 'BOOTH Library Search',
+  'project.booth-library.desc': 'Quick search for your BOOTH library',
+  'project.booth-library.description':
+    'A Chrome extension that lets you search your BOOTH library quickly. Smooth search from purchase history.',
+
+  'project.360-viewer.title': '360-viewer',
+  'project.360-viewer.desc': '360° image viewer in the browser',
+  'project.360-viewer.description':
+    'A 360° image viewer in the browser. You can browse while interacting to experience the appeal of the metaverse.<br><br>You can try the embedded page below.',
+
+  'project.timecard.title': 'TimeCard Web',
+  'project.timecard.desc': 'Attendance management site (school project)',
+  'project.timecard.description':
+    'An attendance management site created as a school project. Built with Java Servlets on Apache Tomcat. Runs on a home server.',
+
+  'project.toc-ad.title': 'TOC-AD',
+  'project.toc-ad.desc': 'WordPress plugin that adds ad images under the table of contents',
+  'project.toc-ad.description':
+    'A WordPress plugin that automatically adds ad images below the table of contents.',
+
+  // Gallery
+  'gallery.sectionTitle': 'Gallery',
+  'gallery.desc': 'Memories from VRChat!',
+  'gallery.caption1': 'Summer ☀️',
+  'gallery.caption2': 'JPT Party 🎉',
+  'gallery.caption3': 'Beautiful View ✨',
+  'gallery.caption4': 'Street Snap 📸',
+  'gallery.caption5': 'Memories...',
+  'gallery.caption6': 'Cute!',
+
+  // Links (labels are often kept as-is; add if you want different wording)
+  'links.twitter': 'X(Twitter)',
+  'links.twitch': 'Twitch',
+  'links.booth': 'BOOTH',
+  'links.github': 'GitHub',
+
+  // Footer
+  'footer.text': 'Made with by Amai Natuki',
+};

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,7 @@
 // Main JavaScript entry point
 import './style.css';
 import { projects } from './projects.js';
+import { en } from './english.js';
 
 console.log('Hello from mu-natuki.com!');
 
@@ -36,6 +37,59 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
+  // --- Language (i18n) ---
+  const defaultTexts = {};
+  const defaultAria = {};
+
+  document.querySelectorAll('[data-i18n]').forEach((el) => {
+    defaultTexts[el.dataset.i18n] = el.textContent;
+  });
+  document.querySelectorAll('[data-i18n-html]').forEach((el) => {
+    defaultTexts[el.dataset.i18nHtml] = el.innerHTML;
+  });
+  document.querySelectorAll('[data-i18n-aria]').forEach((el) => {
+    defaultAria[el.dataset.i18nAria] = el.getAttribute('aria-label') ?? '';
+  });
+
+  const applyTranslations = (lang) => {
+    const t = lang === 'en' ? en : defaultTexts;
+    const a = lang === 'en' ? en : defaultAria;
+
+    document.querySelectorAll('[data-i18n]').forEach((el) => {
+      const key = el.dataset.i18n;
+      const value = t[key];
+      if (value !== undefined) el.textContent = value;
+    });
+    document.querySelectorAll('[data-i18n-html]').forEach((el) => {
+      const key = el.dataset.i18nHtml;
+      const value = t[key];
+      if (value !== undefined) el.innerHTML = value;
+    });
+    document.querySelectorAll('[data-i18n-aria]').forEach((el) => {
+      const key = el.dataset.i18nAria;
+      const value = a[key];
+      if (value !== undefined) el.setAttribute('aria-label', value);
+    });
+  };
+
+  const langToggle = document.getElementById('lang-toggle');
+  const langLabel = document.querySelector('.lang-label');
+  const savedLang = localStorage.getItem('lang') || 'ja';
+  html.setAttribute('lang', savedLang);
+  applyTranslations(savedLang);
+  if (langLabel) langLabel.textContent = savedLang === 'en' ? en['lang.label'] : '日本語';
+
+  if (langToggle) {
+    langToggle.addEventListener('click', () => {
+      const current = localStorage.getItem('lang') || 'ja';
+      const next = current === 'ja' ? 'en' : 'ja';
+      localStorage.setItem('lang', next);
+      html.setAttribute('lang', next);
+      applyTranslations(next);
+      if (langLabel) langLabel.textContent = next === 'en' ? en['lang.label'] : '日本語';
+    });
+  }
+
   // Modal Elements
   const modalOverlay = document.getElementById('project-modal');
   const modalCloseBtn = document.getElementById('modal-close');
@@ -66,8 +120,16 @@ document.addEventListener('DOMContentLoaded', () => {
     const project = projects.find(p => p.id === projectId);
     if (!project) return;
 
-    modalTitle.textContent = project.title;
-    modalDesc.innerHTML = formatDescriptionHtml(project.description);
+    const lang = localStorage.getItem('lang') || 'ja';
+    const titleKey = `project.${projectId}.title`;
+    const descKey = `project.${projectId}.description`;
+    const title = lang === 'en' && en[titleKey] ? en[titleKey] : project.title;
+    const description = lang === 'en' && en[descKey] ? en[descKey] : project.description;
+
+    modalTitle.textContent = title;
+    modalDesc.innerHTML = lang === 'en' && en[descKey]
+      ? en[descKey]
+      : formatDescriptionHtml(description);
 
     // Media Handling
     modalMedia.innerHTML = ''; // Clear previous

--- a/src/style.css
+++ b/src/style.css
@@ -612,6 +612,52 @@ h2::after {
   border-color: var(--accent-sub);
 }
 
+/* Language Toggle (below theme toggle) - same size as theme toggle */
+.lang-toggle {
+  position: fixed;
+  top: 5rem;
+  right: 1.5rem;
+  width: 50px;
+  height: 50px;
+  padding: 0;
+  border-radius: 50%;
+  background: var(--card-bg);
+  border: 3px solid var(--accent-sub);
+  box-shadow: 4px 4px 0px var(--shadow-color);
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0;
+  font-family: var(--font-body);
+  color: var(--text-primary);
+  z-index: 1000;
+  transition: all 0.3s ease;
+}
+
+.lang-toggle:hover {
+  transform: translateY(-3px);
+  box-shadow: 6px 6px 0px var(--accent-main);
+  border-color: var(--accent-main);
+}
+
+.lang-icon {
+  font-size: 1rem;
+  line-height: 1;
+}
+
+.lang-toggle .lang-label {
+  font-size: 0.5rem;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+[data-theme="dark"] .lang-toggle {
+  background: var(--card-bg);
+  border-color: var(--accent-sub);
+}
+
 /* Footer */
 footer {
   padding: 3rem;
@@ -735,6 +781,22 @@ footer {
     width: 45px;
     height: 45px;
     font-size: 1.3rem;
+  }
+
+  .lang-toggle {
+    top: 4.2rem;
+    right: 1rem;
+    width: 45px;
+    height: 45px;
+    padding: 0;
+  }
+
+  .lang-toggle .lang-icon {
+    font-size: 0.9rem;
+  }
+
+  .lang-toggle .lang-label {
+    font-size: 0.45rem;
   }
 }
 


### PR DESCRIPTION
## 概要
サイト内の表示を日本語・英語で切り替えられるようにしました。

## 変更内容
- **言語切替ボタン**: テーマ切替ボタンの下に「日本語 / English」切替ボタンを追加
- **index.html**: 翻訳対象テキストに `data-i18n` / `data-i18n-html` / `data-i18n-aria` を付与
- **english.js**: 上記キーに対応する英語テキストを定義（新規作成）
- **main.js**: 言語の読み込み・適用・切替ロジックを追加（localStorage で選択を保持）
- **モーダル**: プロジェクト詳細のタイトル・説明も選択中の言語で表示
- **style.css**: 言語ボタンのスタイルを追加（テーマボタンと同じ 50×50px の円形）

## 動作
- 言語ボタンクリックで「日本語」⇔「English」を切り替え
- 選択した言語は localStorage に保存され、次回訪問時も維持
- ヒーロー・プロフィール・プロジェクト・ギャラリー・フッターなど、主要な文言を両言語で表示